### PR TITLE
fix text overlaps with flame icon

### DIFF
--- a/src/lib/autofill-utils.ts
+++ b/src/lib/autofill-utils.ts
@@ -48,15 +48,10 @@ export const getDaxBoundingBox = (
     height: inputHeight
   } = input.getBoundingClientRect()
 
-  const inputRightPadding = Number.parseInt(
-    window.getComputedStyle(input).paddingRight,
-    10
-  )
-
   const width = 30
   const height = 30
   const top = inputTop + (inputHeight - height) / 2
-  const right = inputRight - inputRightPadding
+  const right = inputRight 
   const left = right - width
   const bottom = top + height
 
@@ -104,8 +99,8 @@ export const getBasicStyles = (input: HTMLInputElement, icon: string) => ({
   }`,
   'background-position': 'center right',
   'background-repeat': 'no-repeat',
-  'background-origin': 'content-box',
   'background-image': `url(${icon})`,
+  'padding-right': '24px',
   transition: 'background 0s'
 })
 


### PR DESCRIPTION
Now it should look like this
![image](https://github.com/irazasyed/email-masker/assets/32911537/e0a6c363-bbe8-443f-a343-1eac5c8ce539)

the trick is to remove `background-origin: content-box` and add `right-padding` so that background icon sticks to the edge of input, while text is only visible for `100% - right-padding` px

since we've explicitly defined input right padding, no need to subtract it anymore when checking for Dax